### PR TITLE
Attempt to fix a few bugs

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -195,7 +195,7 @@ local function parse_bullet(bullet_line)
     if bullet.indent > 0 then
         local section = find_header_or_list(bullet.start - 1)
         while true do
-            if not section.type:match("list") then
+            if not section or not section.type or not section.type:match("list") then
                 -- Can't find parent even though there is supposed to be one
                 break
             elseif vim.fn.indent(section.line) < bullet.indent then

--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -465,7 +465,7 @@ function M.fold()
         if section.type:match("list") then
             local bullet = parse_bullet(section.line)
 
-            if line_num < bullet.start or line_num > bullet.stop then
+            if bullet and (line_num < bullet.start or line_num > bullet.stop) then
                 -- cursor isn't inside the list
                 bullet = nil
             end


### PR DESCRIPTION
The first change I made was for a bug that appeared when editing YAML frontmatter tags in a Markdown document.

When hitting enter to go to the next line I'd get the following traceback:

```
tt/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:198: attempt to index local 'section' (a nil value)                                                                             stack traceback:                                                                                                                                                                            ^I...tt/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:198: in function 'parse_bullet'                                                                                               ^I...tt/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:371: in function <...tt/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:367>
```

Or if my cursor happened to be on one of the frontmatter open / close declarations `---` and I hit tab I'd get this traceback:

```
tt/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:468: attempt to index local 'bullet' (a nil value)
stack traceback:
^I...tt/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:468: in function <...tt/.local/share/nvim/lazy/nvim-markdo
wn/lua/markdown.lua:447>
```

I _think_ I've managed to fix both of them without breaking anything else. :) 

Time will tell, I use your plugin quite a lot, so thank you!