### PR TITLE
FIX: `BufWinLeave` non-silent error when leaving LSP floating views

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -731,9 +731,18 @@ function! s:MarkdownClearSyntaxVariables()
 endfunction
 
 augroup Mkd
-    autocmd!
-    autocmd BufWinLeave,BufUnload,BufWritePost,InsertEnter,InsertLeave,CursorHold,CursorHoldI <buffer> if &filetype == 'markdown' && !v:lua.vim.api.nvim_win_get_config(0).relative | call <SID>MarkdownRefreshSyntax(0) | endif
-    autocmd BufWinEnter <buffer> if &filetype == 'markdown' && !v:lua.vim.api.nvim_win_get_config(0).relative | silent! loadview | call <SID>MarkdownRefreshSyntax(1) | setlocal foldmethod=manual | endif
+    autocmd! * <buffer>
+    autocmd BufWinLeave <buffer> silent! mkview!
+    autocmd BufWinEnter <buffer> silent! loadview
+    autocmd BufWinEnter <buffer> call s:MarkdownRefreshSyntax(1)
+    " workaround, even without options in viewoptions it still saves this
+    " so it needs to be reset every time so that someone who has set their own
+    " foldmethod(not manual) isn't stuck on it.
+    autocmd BufWinEnter <buffer> setlocal foldmethod=manual
+    autocmd BufUnload <buffer> call s:MarkdownClearSyntaxVariables()
+    autocmd BufWritePost <buffer> call s:MarkdownRefreshSyntax(0)
+    autocmd InsertEnter,InsertLeave <buffer> call s:MarkdownRefreshSyntax(0)
+    autocmd CursorHold,CursorHoldI <buffer> call s:MarkdownRefreshSyntax(0)
 augroup END
 
 function! Foldtext_markdown()

--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -731,18 +731,9 @@ function! s:MarkdownClearSyntaxVariables()
 endfunction
 
 augroup Mkd
-    autocmd! * <buffer>
-    autocmd BufWinLeave <buffer> mkview!
-    autocmd BufWinEnter <buffer> silent! loadview
-    autocmd BufWinEnter <buffer> call s:MarkdownRefreshSyntax(1)
-    " workaround, even without options in viewoptions it still saves this
-    " so it needs to be reset every time so that someone who has set their own
-    " foldmethod(not manual) isn't stuck on it.
-    autocmd BufWinEnter <buffer> setlocal foldmethod=manual
-    autocmd BufUnload <buffer> call s:MarkdownClearSyntaxVariables()
-    autocmd BufWritePost <buffer> call s:MarkdownRefreshSyntax(0)
-    autocmd InsertEnter,InsertLeave <buffer> call s:MarkdownRefreshSyntax(0)
-    autocmd CursorHold,CursorHoldI <buffer> call s:MarkdownRefreshSyntax(0)
+    autocmd!
+    autocmd BufWinLeave,BufUnload,BufWritePost,InsertEnter,InsertLeave,CursorHold,CursorHoldI <buffer> if &filetype == 'markdown' && !v:lua.vim.api.nvim_win_get_config(0).relative | call <SID>MarkdownRefreshSyntax(0) | endif
+    autocmd BufWinEnter <buffer> if &filetype == 'markdown' && !v:lua.vim.api.nvim_win_get_config(0).relative | silent! loadview | call <SID>MarkdownRefreshSyntax(1) | setlocal foldmethod=manual | endif
 augroup END
 
 function! Foldtext_markdown()


### PR DESCRIPTION
This fixes #17. Worked on my end - looks good.

Since it is such a small change, I don't see the need for anything else. Feel free to request any missing part to the pr @ixru.  

Thank you for your work.