### PR TITLE
Change special keycode "<80><fd>h" handling in "key_callback" function for multi-byte user input

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -14,7 +14,7 @@ local function key_callback(key)
     local backspace_term = vim.api.nvim_replace_termcodes("<BS>",true, true, true)
 
     -- It sends some key on o and O "<80><fd>h", which is some special key I didn't ask for.
-    if should_run_callback and not (key:len() == 3 and key ~= backspace_term) then
+    if should_run_callback and not (key == '\x80\xfdh' and key ~= backspace_term) then
         if key == backspace_term then
             M.backspace()
         end


### PR DESCRIPTION
Dear Maintainers,

I have encountered an issue where the `key_callback` function mishandles user input of multi-byte characters (such as `あ`) when used with a list item, incorrectly interpreting the input as the special key `<80><fd>h`.
While the current method of using `key:len() == 3` is a straightforward and effective way to detect special characters or other unique inputs, it unfortunately fails to accommodate multi-byte characters.

To address this, I propose changing the detection logic from using the `len()` check to a specific character check `== '\x80\xfdh'`. I am aware that this approach has both advantages and disadvantages, but I believe it would significantly improve the experience for users who input multi-byte characters.

I kindly ask you to consider this change for the benefit of our multi-byte character users.

Thank you for your attention and consideration.