### PR TITLE
Fix `vim_markdown_conceal` being hardcoded / not accessible

### DIFF
--- a/ftplugin/markdown.vim
+++ b/ftplugin/markdown.vim
@@ -752,7 +752,7 @@ endfunction
 
 setlocal comments=b:> " blockquote
 setlocal formatoptions+=r " auto-insert > on newline
-setlocal conceallevel=2
+let &l:conceallevel = exists('g:vim_markdown_conceal') ? g:vim_markdown_conceal : 2
 setlocal viewoptions=folds,cursor
 setlocal foldtext=Foldtext_markdown()
 setlocal foldopen-=undo


### PR DESCRIPTION
Hey folks, 

I've been dying over manually setting `vim.o.conceallevel` everytime I'm in a markdown file because of this slight bug (mentioned on #21, #18 and probably #11). 

@ixru I know you probably want something better, and I've seen your references to its buggy state and/or alternatives. I didn't invest much time to investigate the exact origin of the problem. It just got fixed when disabling this plugin.

Regardless; **this PR fixes it on my end**, it just checks if there's a `g:vim_markdown_conceal` set before using `2` as the local `conceallevel` value.

Feel free to request any changes, I'm open to help (keep in mind I know nothing about vimscript, I just asked Mister GPT for a ternary). 

Appreciate your time! 🍻 