### PR TITLE
Correctly follow absolute and relative link paths

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -513,7 +513,12 @@ function M.follow_link()
             vim.fn.search("^#* "..link.url:sub(2))
         else
             -- a file
-            vim.cmd("e " .. link.url)
+            if string.match(link.url, "^[~/]") then
+                vim.cmd("e " .. link.url)
+            else
+                -- a relative path
+                vim.cmd("e " .. vim.fn.expand('%:p:h') .. '/' .. link.url)
+            end
         end
     elseif word then
         if word.text:match("^https?://") then


### PR DESCRIPTION
As per the original markdown specifications, markdown links that link to files should be relative paths. This PR simply converts file paths from links to absolute paths when needed to ensure when they are followed, the correct file is opened. Here is an example situation that explains why this is needed: 

- user is in home dir
-  opens a file `nvim ~/.config/nvim/README.md`
- hits `<cr>` on link in that file that looks like this: `[this lua file](lua/plugins/plugin.lua)`
- this unexpectedly opens `~/lua/plugins/plugin.lua` (can be verified with `:echo expand('%:p')`)