### PR TITLE
Disable creating links as fallback for return

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -519,10 +519,6 @@ function M.follow_link()
         if word.text:match("^https?://") then
             -- Bare url i.e without link syntax
             vim.call("netrw#BrowseX", word.text, 0)
-        else
-            -- create a link
-            local filename = string.lower(word.text:gsub("%s","_") .. ".md")
-            vim.cmd('norm! "_ciW[' .. word.text .. '](' .. filename ..')')
         end
     end
 end


### PR DESCRIPTION
As per the name, the function `follow_link()`, which is called by default by `<CR>`, should probably not create a link when it can't follow a link. To preserve existing behavior, I simply created a global variable that can optionally be changed in a user's config to disable this fallback behavior. 