### PR TITLE
Open links to files at correct line number if specified

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -512,8 +512,12 @@ function M.follow_link()
             -- an anchor
             vim.fn.search("^#* "..link.url:sub(2))
         else
-            -- a file
-            vim.cmd("e " .. link.url)
+            if string.match(link.url, "^[~/]") then
+                vim.cmd("e " .. link.url)
+            else
+                -- a relative path
+                vim.cmd("e " .. vim.fn.expand('%:p:h') .. '/' .. link.url)
+            end
         end
     elseif word then
         if word.text:match("^https?://") then

--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -512,11 +512,27 @@ function M.follow_link()
             -- an anchor
             vim.fn.search("^#* "..link.url:sub(2))
         else
-            if string.match(link.url, "^[~/]") then
-                vim.cmd("e " .. link.url)
-            else
-                -- a relative path
-                vim.cmd("e " .. vim.fn.expand('%:p:h') .. '/' .. link.url)
+            -- a file
+            -- check if path conatains line number (ex. file.md#L10)
+            local line_number = link.url:match("#L(%d+)$") or ""
+            if line_number ~= "" then
+                -- remove line number info if it exists
+                line_number = "+" .. line_number .. " "
+                link.url = link.url:gsub("#L%d+$", "")
+            end
+
+            -- try to follow link
+            local ok, _ = pcall(function ()
+                if string.match(link.url, "^[~/]") then
+                    vim.cmd("e " .. line_number .. link.url)
+                else
+                    -- a relative path
+                    vim.cmd("e " .. line_number .. vim.fn.expand('%:p:h') .. '/' .. link.url)
+                end
+            end)
+
+            if not ok then
+                vim.notify("Invalid link: " .. link.url, vim.log.levels.ERROR)
             end
         end
     elseif word then


### PR DESCRIPTION
Following Github flavored markdown convention, if a link to a file has a `#L{number}` at the end of it, it should open that file at the specified line number. This implements that and includes some error checking to account for if the path is invalid. If this should be split into another PR please let me know. Also this might need to change if/when #25 gets merged. 