### PR TITLE
Better follow anchor links in TOC

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -510,7 +510,7 @@ function M.follow_link()
             vim.call("netrw#BrowseX", link.url, 0)
         elseif link.url:match("^#") then
             -- an anchor
-            vim.fn.search("^#* "..link.url:sub(2))
+            vim.fn.search("^#* "..link.url:sub(2):gsub("-", "[%- ]"))
         else
             -- a file path
 


### PR DESCRIPTION
Links to headers in markdown are formatted in a way where any spaces in the header's title is replaced with a dash. The current implementation does not account for this, and following links to headers that include spaces does not work. 

If we replace all dashes in the link URL with some regex, we can follow links a little better. Of course there is still some ambiguity here, but implementing a fully "correct" link following system is a bit more involved. We could theoretically create a dictionary that stores all the headers, checks them for uniqueness, and appends a number to the end of non-unique header names, buuut I was a bit too lazy to fix my half-backed implementation of that. (the number thing is how GitHub handles this ambiguity and I think how the markdown spec says it should be handled)

Anyways this is a pretty easy fix that will cover most cases of this problem.