### PR TITLE
Fix opening links without relying on netrw

### DIFF
--- a/lua/markdown.lua
+++ b/lua/markdown.lua
@@ -507,7 +507,7 @@ function M.follow_link()
     if link and link.url then
         if link.url:match("^https?://") then
             -- a link
-            vim.call("netrw#BrowseX", link.url, 0)
+            vim.ui.open(link.url)
         else
             -- a file path/anchor
 
@@ -550,7 +550,7 @@ function M.follow_link()
     elseif word then
         if word.text:match("^https?://") then
             -- Bare url i.e without link syntax
-            vim.call("netrw#BrowseX", word.text, 0)
+            vim.ui.open(link.url)
         end
     end
 end


### PR DESCRIPTION
The current implementation can throw this error: 
```
Vim:E117: Unknown function: netrw#BrowseX
stack traceback:
	[C]: in function 'call'
	...as/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:510: in function <...as/.local/share/nvim/lazy/nvim-markdown/lua/markdown.lua:504>
```
if the netrwPlugin plugin is not enabled. This is fairly common since not many people use netrw anymore and enabling it just increases startup time redundantly. 